### PR TITLE
Fix: multipart api improvement

### DIFF
--- a/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/ClientWorld$ClientEntityHandlerMixin.java
+++ b/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/ClientWorld$ClientEntityHandlerMixin.java
@@ -1,32 +1,40 @@
 package dev.spiritstudios.specter.mixin.client.entity;
 
+
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 
 import dev.spiritstudios.specter.api.entity.EntityPart;
 import dev.spiritstudios.specter.api.entity.PartHolder;
-import dev.spiritstudios.specter.impl.entity.EntityPartWorld;
 
 @Mixin(targets = "net/minecraft/client/world/ClientWorld$ClientEntityHandler")
 public abstract class ClientWorld$ClientEntityHandlerMixin {
-	@Inject(method = "startTracking(Lnet/minecraft/entity/Entity;)V", at = @At("TAIL"))
+
+	@Shadow
+	@Final
+	ClientWorld field_27735;
+
+	@Inject(method = "startTracking(Lnet/minecraft/entity/Entity;)V", at = @At("RETURN"))
 	private void startTracking(Entity entity, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
-				((EntityPartWorld) entity.getWorld()).specter$parts().put(part.getId(), part);
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
+				this.field_27735.specter$getParts().put(part.getId(), part);
 			}
 		}
 	}
 
-	@Inject(method = "stopTracking(Lnet/minecraft/entity/Entity;)V", at = @At("TAIL"))
+	@Inject(method = "stopTracking(Lnet/minecraft/entity/Entity;)V", at = @At("RETURN"))
 	private void stopTracking(Entity entity, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
-				((EntityPartWorld) entity.getWorld()).specter$parts().remove(part.getId(), part);
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
+				this.field_27735.specter$getParts().remove(part.getId(), part);
 			}
 		}
 	}

--- a/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/EntityRendererMixin.java
+++ b/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/EntityRendererMixin.java
@@ -16,10 +16,11 @@ import dev.spiritstudios.specter.api.entity.PartHolder;
 
 @Mixin(EntityRenderer.class)
 public abstract class EntityRendererMixin {
+
 	@Inject(method = "appendHitboxes", at = @At("HEAD"))
 	private void appendHitboxes(Entity entity, ImmutableList.Builder<EntityHitbox> builder, float tickProgress, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
 				Box box = part.getBoundingBox();
 				builder.add(new EntityHitbox(
 						box.minX - entity.getX(),

--- a/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/LivingEntityRendererMixin.java
+++ b/specter-entity/src/client/java/dev/spiritstudios/specter/mixin/client/entity/LivingEntityRendererMixin.java
@@ -16,10 +16,11 @@ import dev.spiritstudios.specter.api.entity.PartHolder;
 
 @Mixin(LivingEntityRenderer.class)
 public abstract class LivingEntityRendererMixin {
+
 	@Inject(method = "appendHitboxes(Lnet/minecraft/entity/LivingEntity;Lcom/google/common/collect/ImmutableList$Builder;F)V", at = @At("HEAD"))
 	private void appendHitboxes(LivingEntity entity, ImmutableList.Builder<EntityHitbox> builder, float tickProgress, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
 				Box box = part.getBoundingBox();
 				builder.add(new EntityHitbox(
 						box.minX - entity.getX(),

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/api/entity/EntityPart.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/api/entity/EntityPart.java
@@ -1,5 +1,7 @@
 package dev.spiritstudios.specter.api.entity;
 
+import net.minecraft.entity.EntityPose;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.entity.Entity;
@@ -16,14 +18,15 @@ import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
 
 public abstract class EntityPart<T extends Entity> extends Entity {
-	private final T owner;
-	private final EntityDimensions dims;
+	protected final T owner;
+	protected final EntityDimensions dimensions;
 	private Vec3d relativePos = new Vec3d(0, 0, 0);
 
 	public EntityPart(T owner, EntityDimensions dimensions) {
 		super(owner.getType(), owner.getWorld());
 		this.owner = owner;
-		this.dims = dimensions;
+		this.dimensions = dimensions;
+		this.calculateDimensions();
 	}
 
 	@Override
@@ -32,18 +35,17 @@ public abstract class EntityPart<T extends Entity> extends Entity {
 
 	@Override
 	protected void readCustomDataFromNbt(NbtCompound nbt) {
-
 	}
 
 	@Override
 	protected void writeCustomDataToNbt(NbtCompound nbt) {
-
 	}
 
 	public Vec3d getRelativePos() {
 		return relativePos;
 	}
 
+	@SuppressWarnings("unused")
 	public void setRelativePos(Vec3d relativePos) {
 		this.relativePos = relativePos;
 	}
@@ -55,7 +57,7 @@ public abstract class EntityPart<T extends Entity> extends Entity {
 
 	@Override
 	protected Box calculateDefaultBoundingBox(Vec3d pos) {
-		return this.dims == null ? super.calculateDefaultBoundingBox(pos) : this.dims.getBoxAt(pos);
+		return this.dimensions == null ? super.calculateDefaultBoundingBox(pos) : this.dimensions.getBoxAt(pos);
 	}
 
 	@Override
@@ -85,5 +87,10 @@ public abstract class EntityPart<T extends Entity> extends Entity {
 
 	public T getOwner() {
 		return owner;
+	}
+
+	@Override
+	public EntityDimensions getDimensions(EntityPose pose) {
+		return this.dimensions;
 	}
 }

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/api/entity/PartHolder.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/api/entity/PartHolder.java
@@ -5,5 +5,5 @@ import java.util.List;
 import net.minecraft.entity.Entity;
 
 public interface PartHolder<T extends Entity> {
-	List<EntityPart<T>> parts();
+	List<EntityPart<T>> getEntityParts();
 }

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/impl/entity/EntityPartWorld.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/impl/entity/EntityPartWorld.java
@@ -5,5 +5,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import dev.spiritstudios.specter.api.entity.EntityPart;
 
 public interface EntityPartWorld {
-	Int2ObjectMap<EntityPart<?>> specter$parts();
+	default Int2ObjectMap<EntityPart<?>> specter$getParts() {
+		throw new UnsupportedOperationException("Injected interface should be implemented by mixin!");
+	}
 }

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/PlayerEntityMixin.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/PlayerEntityMixin.java
@@ -11,9 +11,9 @@ import dev.spiritstudios.specter.api.entity.EntityPart;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin {
+
 	@ModifyVariable(method = "attack", at = @At("STORE"), ordinal = 1)
 	private Entity attack(Entity value) {
-		if (value instanceof EntityPart<?> part) return part.getOwner();
-		return value;
+		return value instanceof EntityPart<?> part ? part.getOwner() : value;
 	}
 }

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerChunkLoadingManagerMixin.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerChunkLoadingManagerMixin.java
@@ -11,6 +11,7 @@ import dev.spiritstudios.specter.api.entity.EntityPart;
 
 @Mixin(ServerChunkLoadingManager.class)
 public abstract class ServerChunkLoadingManagerMixin {
+
 	@WrapMethod(method = "loadEntity")
 	private void loadEntity(Entity entity, Operation<Void> original) {
 		if (entity instanceof EntityPart<?>) return;

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerWorld$ServerEntityHandlerMixin.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerWorld$ServerEntityHandlerMixin.java
@@ -1,23 +1,30 @@
 package dev.spiritstudios.specter.mixin.entity;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
 
 import dev.spiritstudios.specter.api.entity.EntityPart;
 import dev.spiritstudios.specter.api.entity.PartHolder;
-import dev.spiritstudios.specter.impl.entity.EntityPartWorld;
 
 @Mixin(targets = "net/minecraft/server/world/ServerWorld$ServerEntityHandler")
 public abstract class ServerWorld$ServerEntityHandlerMixin {
+
+	@Shadow
+	@Final
+	ServerWorld field_26936;
+
 	@Inject(method = "startTracking(Lnet/minecraft/entity/Entity;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;updateEventHandler(Ljava/util/function/BiConsumer;)V"))
 	private void startTracking(Entity entity, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
-				((EntityPartWorld) entity.getWorld()).specter$parts().put(part.getId(), part);
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
+				this.field_26936.specter$getParts().put(part.getId(), part);
 			}
 		}
 	}
@@ -25,8 +32,8 @@ public abstract class ServerWorld$ServerEntityHandlerMixin {
 	@Inject(method = "stopTracking(Lnet/minecraft/entity/Entity;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;updateEventHandler(Ljava/util/function/BiConsumer;)V"))
 	private void stopTracking(Entity entity, CallbackInfo ci) {
 		if (entity instanceof PartHolder<?> partHolder) {
-			for (EntityPart<?> part : partHolder.parts()) {
-				((EntityPartWorld) entity.getWorld()).specter$parts().remove(part.getId(), part);
+			for (EntityPart<?> part : partHolder.getEntityParts()) {
+				this.field_26936.specter$getParts().remove(part.getId(), part);
 			}
 		}
 	}

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerWorldMixin.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/ServerWorldMixin.java
@@ -2,18 +2,18 @@ package dev.spiritstudios.specter.mixin.entity;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.server.world.ServerWorld;
 
-import dev.spiritstudios.specter.impl.entity.EntityPartWorld;
-
 @Mixin(ServerWorld.class)
-public abstract class ServerWorldMixin implements EntityPartWorld {
+public abstract class ServerWorldMixin extends WorldMixin {
+
 	@ModifyReturnValue(method = "getEntityOrDragonPart", at = @At("RETURN"))
 	private Entity getEntityOrDragonPart(Entity original, @Local(argsOnly = true) int id) {
-		return original != null ? original : this.specter$parts().get(id);
+		return original != null ? original : this.specter$parts.get(id);
 	}
 }

--- a/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/WorldMixin.java
+++ b/specter-entity/src/main/java/dev/spiritstudios/specter/mixin/entity/WorldMixin.java
@@ -30,7 +30,7 @@ public abstract class WorldMixin implements EntityPartWorld {
 	@Unique
 	protected final Int2ObjectMap<EntityPart<?>> specter$parts = new Int2ObjectOpenHashMap<>();
 
-	@Inject(method = "method_47576", at = @At("RETURN"), cancellable = true)
+	@Inject(method = "method_47576", at = @At("TAIL"), cancellable = true)
 	private static <T extends Entity> void collectEntitiesByTypeLambda(
 			Predicate<? super T> predicate,
 			List<? super T> result,

--- a/specter-entity/src/main/resources/fabric.mod.json
+++ b/specter-entity/src/main/resources/fabric.mod.json
@@ -35,6 +35,9 @@
 			"badges": [
 				"library"
 			]
+		},
+		"loom:injected_interfaces": {
+			"net/minecraft/class_1937": ["dev/spiritstudios/specter/impl/entity/EntityPartWorld"]
 		}
 	}
 }

--- a/specter-entity/src/testmod/java/dev/spiritstudios/testmod/entity/mixin/SilverfishEntityMixin.java
+++ b/specter-entity/src/testmod/java/dev/spiritstudios/testmod/entity/mixin/SilverfishEntityMixin.java
@@ -30,7 +30,7 @@ public class SilverfishEntityMixin extends HostileEntity implements PartHolder<S
 	}
 
 	@Override
-	public List<EntityPart<SilverfishEntity>> parts() {
+	public List<EntityPart<SilverfishEntity>> getEntityParts() {
 		return parts;
 	}
 


### PR DESCRIPTION
Changes:

- Renamed `PartHolder#parts` to `PartHolder#getEntityParts`
- Renamed `EntityPart.dims` to `EntityPart.dimensions` and made it protected
- Made `EntityPart.owner` protected
- Overrode `getDimensions` in `EntityPart`
- Slight mixin changes
- `EntityPartWorld` is now an injected interface